### PR TITLE
Use podman for multi-arch build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-        # this is needed because we restart the docker daemon for experimental
-        # support
-        options: "--restart always"
     name: ${{ matrix.image }}
     strategy:
       fail-fast: false
@@ -82,42 +79,28 @@ jobs:
           IMG_TMP="${BASE_IMAGE/:/-}"
           echo "IMG=${IMG_TMP/-slim}" >>$GITHUB_ENV
           echo "REPO=docker-systemd" >>$GITHUB_ENV
-      - name: Enable experimental support
+      - name: Install qemu-user-static
         run: |
-          config='/etc/docker/daemon.json'
-          if [[ -e "$config" ]]; then
-            sudo sed -i -e 's/{/{ "experimental": true, /' "$config"
-          else
-            echo '{ "experimental": true }' | sudo tee "$config"
-          fi
-          sudo systemctl restart docker
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx (local builds)
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: network=host
-      - name: Build
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          build-args: base_image=${{ matrix.image }}
-          platforms: ${{ matrix.platforms }}
-          push: true
-          tags: localhost:5000/${{ secrets.DOCKER_USER }}/${{ env.REPO }}:${{ env.IMG }}
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+      - name: Build images
+        run: |
+          podman buildx build --platform ${{ matrix.platforms }} \
+            -f ${{ matrix.dockerfile }} \
+            --build-arg base_image=${{ matrix.image }} \
+            --tag localhost:5000/${{ secrets.DOCKER_USER }}/${{ env.REPO }}:${{ env.IMG }}
+          podman images
       - name: Systemd check
         run: |
-          docker run --name test-${{ env.IMG }} -d --privileged \
-          -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-          localhost:5000/${{ secrets.DOCKER_USER }}/${{ env.REPO }}:${{ env.IMG }}
+          podman run --name sys-test --rm -d \
+            localhost:5000/${{ secrets.DOCKER_USER }}/${{ env.REPO }}:${{ env.IMG }}
           # debian 9 takes time to boot
           if [[ "$BASE_IMAGE" == "debian:9-slim" ]]; then
             sleep 100
           else
             sleep 2
           fi
-          docker exec test-${{ env.IMG }} systemd-analyze
+          podman exec -it sys-test systemd-analyze
       - name: Check GitHub settings
         if: >
           (github.event_name == 'push' || github.event_name == 'schedule') &&


### PR DESCRIPTION
This is more transparent and shows directly podman commands used in the CI.